### PR TITLE
Don't crash if system contains no dependencies

### DIFF
--- a/report-generator/src/report_generator/osh_report.py
+++ b/report-generator/src/report_generator/osh_report.py
@@ -51,7 +51,7 @@ class OSHData:
 class OSHReport:
     
     def aggregate_data(self, input_data):
-        data = OSHData()        
+        data = OSHData()
         for component in input_data.get("components", []):
             data.total_deps += 1
             if(data.date_year == ""):

--- a/report-generator/src/report_generator/osh_report.py
+++ b/report-generator/src/report_generator/osh_report.py
@@ -51,8 +51,8 @@ class OSHData:
 class OSHReport:
     
     def aggregate_data(self, input_data):
-        data = OSHData()
-        for component in input_data["components"]:
+        data = OSHData()        
+        for component in input_data.get("components", []):
             data.total_deps += 1
             if(data.date_year == ""):
                 (data.date_year, data.date_month, data.date_day) = OSHReport.format_date(input_data["metadata"]["timestamp"])

--- a/report-generator/src/report_generator/smart_remarks.py
+++ b/report-generator/src/report_generator/smart_remarks.py
@@ -201,7 +201,7 @@ class SmartRemarks:
             if (vulnerability["ratings"][0]["severity"] == "medium") or (vulnerability["ratings"][0]["severity"]=="high") or (vulnerability["ratings"][0]["severity"]=="high"):
                 mentionable_vulnerability_count += 1
         mentionable_license_count = 0
-        for library in libraries["components"]:
+        for library in libraries.get("components", []):
             if (library["properties"][0]["value"] == "CRITICAL") or (library["properties"][0]["value"] == "HIGH") or (library["properties"][0]["value"] == "MEDIUM"):
                 mentionable_license_count += 1
         return f"This system has {mentionable_vulnerability_count} medium or higher risk vulnerable libraries and {mentionable_license_count} licenses with potential legal risks that should be investigated"


### PR DESCRIPTION
Report generation crashes if systems contains no dependencies. This is a fix for that. 