### PR TITLE
Pivot portfolio dependencies to Excel

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ We currently have the following integrations:
 * [Objectives report](objectives-report/) generates charts based on Sigrid objectives, suitable to include in internal reporting. These charts go beyond what is available in the Sigrid user interface, and have a focus on reporting progress over longer periods of time.
 * [Get scope file](get-scope-file/) uses the Sigrid API to retrieve the latest [scope configuration file](https://docs.sigrid-says.com/reference/analysis-scope-configuration.html) that was used by Sigrid.
 * [Report Generator](report-generator/) is a tool/framework designed to generate any kind of report.
+* [Export Portfolio dependencies](export-portfolio-dependencies/) exports to Excel all the third-party open source dependencies of a portfolio.
 
 ## License
 

--- a/export-portfolio-dependencies/README.md
+++ b/export-portfolio-dependencies/README.md
@@ -27,7 +27,11 @@ Before using the system, you need to generate a Sigrid token. Tokens are unique 
 
 ### Run the tool
 
-* Run: `export_portfolio_dependencies.py [-h] --customer CUSTOMER [--output OUTPUT] [--debug]`
+* Run: `export_portfolio_dependencies.py [-h] --customer CUSTOMER [--output OUTPUT] [--pivot] [--debug]`  
+
+The script creates a sheet per system and saves it into a single Excel file. Using `--pivot`, it creates
+a single sheet where all dependencies are pivoted, with an additional column containing a comma-separated list of systems where 
+that single dependency is measured. 
 
 If all goes well, the export should be in the folder where you run the command. Optionally, in the specified filename when passing the `--output` parameter.  
 


### PR DESCRIPTION
Added a tiny additional feature where passing `--pivot` to the Export Portfolio dependencies creates a single Excel sheet with all dependencies, and an additional column with a comma-separated list of systems where that dependency is measured.