### PR TITLE
Adding the option to only list the Mendix versions of all systems

### DIFF
--- a/export-portfolio-dependencies/README.md
+++ b/export-portfolio-dependencies/README.md
@@ -27,13 +27,15 @@ Before using the system, you need to generate a Sigrid token. Tokens are unique 
 
 ### Run the tool
 
-* Run: `export_portfolio_dependencies.py [-h] --customer CUSTOMER [--output OUTPUT] [--pivot] [--debug]`  
+* Run: `export_portfolio_dependencies.py [-h] --customer CUSTOMER [--output OUTPUT] [--pivot] [--mendix_versions] [--debug]`  
 
 The script creates a sheet per system and saves it into a single Excel file. Using `--pivot`, it creates
 a single sheet where all dependencies are pivoted, with an additional column containing a comma-separated list of systems where 
 that single dependency is measured. 
 
 If all goes well, the export should be in the folder where you run the command. Optionally, in the specified filename when passing the `--output` parameter.  
+
+The `--mendix_versions` is an optional field for users using QSM. Using this field retrieves all the different Mendix-Runtime versions used for each system and writes it to the output file. 
 
 #### Troubleshooting
 

--- a/export-portfolio-dependencies/export_portfolio_dependencies.py
+++ b/export-portfolio-dependencies/export_portfolio_dependencies.py
@@ -211,7 +211,7 @@ def parse_arguments():
                         help="Output Excel file name (not path). If not specified, a default name will be used.")
     parser.add_argument("--pivot", action="store_true", help="Generate a single sheet with all dependencies "
                                                              "instead of a sheet per system")
-    parser.add_argument("--mendix_versions", action="store_true", help="Get a full list of Mendix versions only if enabled")
+    parser.add_argument("--mendix_versions_only", action="store_true", help="Get a full list of Mendix versions only if enabled")
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
     return parser.parse_args()
 
@@ -231,7 +231,7 @@ def main():
 
     if args.output:
         output_file = args.output
-    elif args.mendix_versions:
+    elif args.mendix_versions_only:
         output_file = f'{customer_name}-mendix-versions.xlsx'
     else:
         output_file = f'{customer_name}-portfolio-dependencies.xlsx'
@@ -240,7 +240,7 @@ def main():
         logger.info(f"Fetching data for customer: {customer_name}")
         json_data = fetch_api_data(customer_name, token)
         logger.info(f"Data fetched successfully. Processing output...")
-        process_api_output(json_data, output_file, args.pivot, args.mendix_versions)
+        process_api_output(json_data, output_file, args.pivot, args.mendix_versions_only)
         logger.info(f"Data successfully exported to {output_file}")
     except Exception as e:
         logger.exception(f"An error occurred: {e}")


### PR DESCRIPTION
This change adds an option for the export_portfolio_dependencies script to only retrieve the different Mendix-Runtime versions for each system so customers can have a quick overview of all the different Mendix versions used in their portfolio without having to navigate through different systems in Sigrid.