### PR TITLE
Report Generator: Allow setting API context independently

### DIFF
--- a/report-generator/setup.cfg
+++ b/report-generator/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = report-generator
-version = 0.1.0
+version = 0.1.1
 author = Software Improvement Group (SIG)
 author_email = support@softwareimprovementgroup.com
 description = Generate Sigrid reports


### PR DESCRIPTION
This enables more flexibility, for example for when a system name is not derived from cli and needs to be defined later in the process. _check_context() ensures the context is valid before an API call