### PR TITLE
Remove Sigrid Users that are not found via LDAP Sync

### DIFF
--- a/ldap-group-sync/README.md
+++ b/ldap-group-sync/README.md
@@ -1,9 +1,10 @@
 # Sigrid LDAP group synchronization
 
-Synchronizes group memberships from LDAP groups to Sigrid user groups.
+Synchronizes group memberships from LDAP groups to Sigrid user groups. Optionally, it can also create and delete
+Sigrid groups to match LDAP, and remove Sigrid users that are no longer present in LDAP.
 
 Groups are assumed to be connected if the LDAP group and Sigrid user group have the same name. The group memberships
-for each Sigrid user group are then updated, based on the users in the corresponding LDAP group. 
+for each Sigrid user group are then updated, based on the users in the corresponding LDAP group.
 
 The [Sigrid user management API](https://docs.sigrid-says.com/integrations/sigrid-api-documentation.html#user-management)
 is used for interaction between these scripts and Sigrid.
@@ -28,7 +29,7 @@ Configuration is done using environment variables:
 | `SIGRID_LDAP_URL`                  | ldap://ldap.example.com:389          | LDAP URL.                                                         |
 | `SIGRID_LDAP_BIND_DN`              | cn=read-only-admin,dc=example,dc=com | LDAP DN used for authenticating this integration.                 |
 | `SIGRID_LDAP_BIND_PASSWORD`        | (password)                           | LDAP password used for authenticating this integration.           |
-| `SIGRID_LDAP_USER_DN`              | dc=example,dc=com                    | Locations of users to sync.                                       |
+| `SIGRID_LDAP_USER_DN`              | dc=example,dc=com                    | Location of users to sync.                                        |
 | `SIGRID_LDAP_USER_QUERY`           | objectclass=inetOrgPerson            | Query on user DN to get the list of user objects.                 |
 | `SIGRID_LDAP_USER_FIRST_NAME_ATTR` | cn                                   | Name of the LDAP attribute used for users' first names.           |
 | `SIGRID_LDAP_USER_LAST_NAME_ATTR`  | cn                                   | Name of the LDAP attribute used for users' last names.            |
@@ -41,9 +42,20 @@ Configuration is done using environment variables:
 | `LDAP_CA_CERT`                     | myldapcert.pem                       | (Optional) Path to `.pem` file for connecting to LDAP.            |
 
 
+The script also accepts the following optional flags:
+
+| Flag               | Description                                                                                         |
+|--------------------|-----------------------------------------------------------------------------------------------------|
+| `--override-groups` | Creates and deletes Sigrid user groups to match the groups found in LDAP.                          |
+| `--remove-users`    | Removes Sigrid users whose email address is not found in the LDAP user query results.              |
+
 Once all environment variables are in place, you can run the integration:
 
     ./sigrid_ldap_group_sync.py
+
+You can optionally pass one or both flags:
+
+    ./sigrid_ldap_group_sync.py --override-groups --remove-users
 
 You would typically run this as a scheduled job, to periodically perform this synchronization. However, it's also 
 possible to run this manually or ad-hoc.

--- a/ldap-group-sync/sigrid_ldap_group_sync.py
+++ b/ldap-group-sync/sigrid_ldap_group_sync.py
@@ -20,7 +20,7 @@ from argparse import ArgumentParser
 
 from sigridldap.ldap_connection import LdapConfig, LdapConnection
 from sigridldap.sigrid_user_management import SigridUserManagement
-from sigridldap.sync import syncUserGroups, syncGroupMemberships
+from sigridldap.sync import syncUserGroups, syncGroupMemberships, removeUsers
 
 
 def getRequiredEnv(name: str) -> str:
@@ -33,6 +33,7 @@ def getRequiredEnv(name: str) -> str:
 if __name__ == "__main__":
     parser = ArgumentParser(description="Synchronizes group memberships from LDAP groups to Sigrid user groups.")
     parser.add_argument("--override-groups", action="store_true", help="Force-replace all user groups with LDAP groups.")
+    parser.add_argument("--remove-users", action="store_true", help="Remove Sigrid users not found in the LDAP user query.")
     args = parser.parse_args()
 
     sigridURL = os.environ.get("SIGRID_UM_URL", "https://sigrid-says.com")
@@ -58,4 +59,6 @@ if __name__ == "__main__":
 
     if args.override_groups:
         syncUserGroups(sigrid, ldapConnection)
+    if args.remove_users:
+        removeUsers(sigrid, ldapConnection)
     syncGroupMemberships(sigrid, ldapConnection)

--- a/ldap-group-sync/sigridldap/sigrid_user_management.py
+++ b/ldap-group-sync/sigridldap/sigrid_user_management.py
@@ -77,3 +77,6 @@ class SigridUserManagement:
             },
             "isSSO": True
         })
+
+    def deleteUser(self, userId: str):
+        return self.callEndPoint("DELETE", f"/rest/auth/api/user-management/{self.customer}/users/{userId}")

--- a/ldap-group-sync/sigridldap/sync.py
+++ b/ldap-group-sync/sigridldap/sync.py
@@ -62,6 +62,16 @@ def findOrphanGroups(ldapGroups: list[LdapGroup], sigridGroups: dict) -> list[st
     return [groupName for groupName in sigridGroups if groupName not in ldapGroupNames]
 
 
+def removeUsers(sigrid: SigridUserManagement, ldapConnection: LdapConnection) -> None:
+    ldapUserEmails = {user.email for user in ldapConnection.listUsers()}
+    sigridUsers = sigrid.listUsers()
+
+    for sigridUser in sigridUsers:
+        if sigridUser["email"] not in ldapUserEmails:
+            print(f"Removing Sigrid user '{sigridUser['email']}' (not found in LDAP)")
+            sigrid.deleteUser(sigridUser["id"])
+
+
 def findLdapUsers(group: LdapGroup, users: list[LdapUser]) -> Iterator[LdapUser]:
     uids = {user.uid: user for user in users}
 

--- a/ldap-group-sync/test/test_sync.py
+++ b/ldap-group-sync/test/test_sync.py
@@ -14,7 +14,7 @@
 
 from sigridldap.ldap_connection import LdapConfig, LdapConnection
 from sigridldap.sigrid_user_management import SigridUserManagement
-from sigridldap.sync import syncUserGroups, syncGroupMemberships
+from sigridldap.sync import syncUserGroups, syncGroupMemberships, removeUsers
 
 
 OPEN_SOURCE_LDAP_CONFIG = LdapConfig(
@@ -112,6 +112,28 @@ def testAutoCreateMissingSigridUsers():
     ]
 
 
+def testRemoveUsersNotInLdap():
+    sigrid = MockSigridUserManagement()
+    sigrid.existingUsers.append({"id": "1", "email": "tesla@ldap.forumsys.com"})
+    sigrid.existingUsers.append({"id": "2", "email": "notinldap@example.com"})
+
+    removeUsers(sigrid, ldapConnection)
+
+    assert sigrid.actions == [
+        "delete user 2"
+    ]
+
+
+def testRemoveUsersDoesNothingWhenAllPresent():
+    sigrid = MockSigridUserManagement()
+    sigrid.existingUsers.append({"id": "1", "email": "tesla@ldap.forumsys.com"})
+    sigrid.existingUsers.append({"id": "2", "email": "newton@ldap.forumsys.com"})
+
+    removeUsers(sigrid, ldapConnection)
+
+    assert sigrid.actions == []
+
+
 class MockSigridUserManagement(SigridUserManagement):
     def __init__(self):
         super().__init__("https://dummy", "example", "token")
@@ -144,6 +166,10 @@ class MockSigridUserManagement(SigridUserManagement):
 
     def listUsers(self):
         return self.existingUsers
+
+    def deleteUser(self, userId: str):
+        self.actions.append(f"delete user {userId}")
+        self.existingUsers = [user for user in self.existingUsers if user["id"] != userId]
 
     def createUser(self, email: str, firstName: str, lastName: str):
         self.actions.append(f"create user {email}")


### PR DESCRIPTION
**Source:** LDAP or Active Directory (AD) server

**Test Cases:**
- A user without group membership in the source is not created in Sigrid.
- A user with group membership in the source is created in Sigrid and added to the appropriate group.
- A user who does not have group membership in the source but already exists in Sigrid remains in Sigrid.
- A user who is no longer found in the source is deleted from Sigrid.