### PR TITLE
Replace mshick/add-pr-comment with built-in GitHub token

### DIFF
--- a/.github/workflows/sigrid-pullrequest.yml
+++ b/.github/workflows/sigrid-pullrequest.yml
@@ -19,15 +19,10 @@ jobs:
           capability: maintainability,osh,security
         env:
           SIGRID_CI_TOKEN: "${{ secrets.SIGRID_CI_TOKEN }}"
+          SIGRIDCI_GITHUB_COMMENT_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: Archive Sigrid CI artifacts
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: sigrid-ci-results
           path: "sigrid-ci-output/**"
-      - name: "Sigrid pull request feedback"
-        uses: mshick/add-pr-comment@v2
-        if: always()
-        with:
-          message-id: sigrid
-          message-path: sigrid-ci-output/*feedback.md


### PR DESCRIPTION
Removes the mshick/add-pr-comment action and switches to passing GITHUB_TOKEN via SIGRIDCI_GITHUB_COMMENT_TOKEN, consistent with how sigridci itself handles PR comments.